### PR TITLE
Update environment.yml to solve numpy-error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,9 @@
 name: moveapps-python-sdk
 channels:
   - conda-forge
-  - defaults
 dependencies:
-  - qgis=3.30.2
-  - urllib3=1.26.15=pyhd8ed1ab_0
+  - qgis
+  - urllib3
   - pyproj
   - matplotlib
   - branca


### PR DESCRIPTION
Hi Matt,
I am working with Anne Scharf on MoveApps. Recently the translator App that translates data to a `MovingPandas.TrajectoryCollection` was updated, which resulted in your App (and others) giving the error `No module named 'numpy._core.numeric'`. Anne asked me to look into this and I found out that a newer version of numpy needs to be used. Removing the specified versions in your `environment.yml` file allows for a newer version of numpy to be used, which solves the error both locally and in MoveApps.
In addition, I removed the `defaults`-channel from `environment.yml` to avoid needing Anaconda (a generally applied update in MoveApps).
It would be great if you could update your App in MoveApps.
All the best,
Iris